### PR TITLE
destroy image and update modal on hide

### DIFF
--- a/Resources/public/js/comur.imagelibrary.js
+++ b/Resources/public/js/comur.imagelibrary.js
@@ -100,6 +100,10 @@ function destroyImageManager(){
     destroyJCrop();
     $('#image_crop_go_now').unbind('click');
     $('#image_preview').html('<p>Please select or upload an image</p>');
+    
+    $('#selected_image').val('');
+    $('#image_crop_go_now').addClass('hidden');
+    $('#image_upload_tabs a:first').tab('show');
 }
 
 var api;


### PR DESCRIPTION
When you hide the modal and you open it again, the image is still there. 
It cleans all.