### PR TITLE
Update CroppableImageType.php

### DIFF
--- a/Form/Type/CroppableImageType.php
+++ b/Form/Type/CroppableImageType.php
@@ -152,6 +152,6 @@ class CroppableImageType extends AbstractType
         }
 
         $view->vars['options'] = array('uploadConfig' => $uploadConfig, 'cropConfig' => $cropConfig, 'fieldImage' => $fieldImage);
-        $view->vars['attr'] = array('style' => 'opacity: 0;width: 0; max-width: 0; height: 0; max-height: 0;');
+        $view->vars['attr']['style'] = 'opacity: 0;width: 0; max-width: 0; height: 0; max-height: 0;';
     }
 }


### PR DESCRIPTION
If you define the attr "style" this way: $view->vars['attr'] = array('style' => 'opacity: 0;width: 0; max-width: 0; height: 0; max-height: 0;');
Then the attr options are not available on forms fields where you use the CroppableImageType, for example:

->add('image1', CroppableImageType::class, array(
                'attr' => array('class'=>'block1'),
                'uploadConfig' => array(
                    'uploadRoute' => 'comur_api_upload', 		//optional
                    'uploadUrl' => $entity->getUploadRootDir(),       // required - see explanation below (you can also put just a dir path)
                    'webDir' => $entity->getUploadDir(),				// required - see explanation below (you can also put just a dir path)
                    'fileExt' => '*.jpg;*.gif;*.png;*.jpeg', 	//optional
                    'libraryDir' => null, 						//optional
                    'libraryRoute' => 'comur_api_image_library', //optional
                    'showLibrary' => true, 						//optional
                    'saveOriginal' => 'originalImage',			//optional
                    'generateFilename' => true			//optional
                ),
                'cropConfig' => array(
                    'minWidth' => 588,
                    'minHeight' => 300,
                    'aspectRatio' => true, 				//optional
                    'cropRoute' => 'comur_api_crop', 	//optional
                    'forceResize' => false, 			//optional
                    'thumbs' => array( 					//optional
                        array(
                            'maxWidth' => 180,
                            'maxHeight' => 400,
                            'useAsFieldImage' => true  //optional
                        )
                    )
                )
            ))