### PR TITLE
Require jms/translation-bundle ^1.2.2 (Fixes #104)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "twig/twig": "~1.12",
         "twig/extensions": "~1.0",
         "friendsofsymfony/jsrouting-bundle": "@stable",
-	"jms/translation-bundle": "dev-master"
+	"jms/translation-bundle": "^1.2.2"
     },
     "target-dir": "Comur/ImageBundle",
     "autoload": {


### PR DESCRIPTION
Switch jms/translation-bundle dependency from using unstable code to any release between 1.2.2 (the first version to support Symfony 3) and 2.0 (which may break compatibility)