### PR TITLE
add quotes to satisfy sf 3.1 yaml deprecations

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,7 +3,7 @@ parameters:
     comur_gallery_type_class: Comur\ImageBundle\Form\Type\CroppableGalleryType
 services:
     comur_image_bundle.image_type:
-        class: %comur_image_type_class%
+        class: "%comur_image_type_class%"
         tags:
             - { name: form.type, alias: comur_image }
         # arguments: [%comur_image.translation_domain%]

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -8,12 +8,12 @@ services:
             - { name: form.type, alias: comur_image }
         # arguments: [%comur_image.translation_domain%]
     comur_image_bundle.gallery_type:
-        class: %comur_gallery_type_class%
+        class: "%comur_gallery_type_class%"
         tags:
             - { name: form.type, alias: comur_gallery }
-        arguments: [%comur_image.gallery_dir%, %comur_image.thumbs_dir%, %comur_image.gallery_thumb_size%]
+        arguments: ["%comur_image.gallery_dir%", "%comur_image.thumbs_dir%", "%comur_image.gallery_thumb_size%"]
     comur.twig.thumb_extension:
         class: Comur\ImageBundle\Twig\ThumbExtension
         tags:
             - { name: twig.extension }
-        arguments: [%comur_image.cropped_image_dir%, %comur_image.thumbs_dir%, "@service_container", %comur_image.web_dirname%, %comur_image.translation_domain%, %comur_image.gallery_dir%]
+        arguments: ["%comur_image.cropped_image_dir%", "%comur_image.thumbs_dir%", "@service_container", "%comur_image.web_dirname%", "%comur_image.translation_domain%", "%comur_image.gallery_dir%"]


### PR DESCRIPTION
Container parameters enclosed with "%" need to be enclosed in quotes